### PR TITLE
:herb: `.fernignore` only ignores README

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,4 +1,3 @@
 # Specify files that shouldn't be modified by Fern
 
 README.md
-src/seam/client.py


### PR DESCRIPTION
We don't need to .fernignore the client since we no longer need the polling logic