### PR TITLE
fix: add test and update README

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,3 +1,4 @@
 # Specify files that shouldn't be modified by Fern
 
 README.md
+tests/test_client.py

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ poetry add fern-seam
 ```python
 from seam.client import Seam
 
-seam_client = Seam(token="MY_TOKEN")
+seam_client = Seam(api_key="MY_SEAM_API_KEY")
 
 response = seam_client.access_codes.update_and_wait_until_ready(
     access_code_id="my access code id",
@@ -42,7 +42,7 @@ This SDK also includes an async client, which supports the `await` syntax:
 ```python
 from seam.client import AsyncSeam
 
-seam_client = AsyncSeam(token="MY_TOKEN")
+seam_client = AsyncSeam(api_key="MY_SEAM_API_KEY")
 
 async def update_access_code() -> None:
     response = seam_client.access_codes.update_and_wait_until_ready(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,8 @@
-import pytest
+from seam.client import Seam
+import os
 
-# Get started with writing tests with pytest at https://docs.pytest.org
-@pytest.mark.skip(reason="Unimplemented")
-def test_client() -> None:
-    assert True == True
+seam_client = Seam(api_key=os.environ.get("SEAM_API_KEY"))
+
+def test_get_devices() -> None:
+    devices_response = seam_client.devices.list()
+    assert len(devices_response.devices) > 0


### PR DESCRIPTION
Tests can be run with the command
```
poetry install
poetry run pytest tests/test_client.py
```